### PR TITLE
AIXM Export Feature

### DIFF
--- a/tofpa_dockwidget.py
+++ b/tofpa_dockwidget.py
@@ -47,6 +47,7 @@ class TofpaDockWidget(QDockWidget, FORM_CLASS):
         self.initialElevationSpin.setValue(0.0)
         self.endElevationSpin.setValue(0.0)
         self.exportToKmzCheckBox.setChecked(False)
+        self.exportToAixmCheckBox.setChecked(False)
         self.useSelectedFeatureCheckBox.setChecked(True)
         self.directionCombo.setCurrentIndex(1)  # Default to "End to Start (-1)"
         
@@ -117,7 +118,8 @@ class TofpaDockWidget(QDockWidget, FORM_CLASS):
             'runway_layer_id': self.runwayLayerCombo.currentLayer().id() if self.runwayLayerCombo.currentLayer() else None,
             'threshold_layer_id': self.thresholdLayerCombo.currentLayer().id() if self.thresholdLayerCombo.currentLayer() else None,
             'use_selected_feature': self.useSelectedFeatureCheckBox.isChecked(),
-            'export_kmz': self.exportToKmzCheckBox.isChecked()
+            'export_kmz': self.exportToKmzCheckBox.isChecked(),
+            'export_aixm': self.exportToAixmCheckBox.isChecked()
         }
 
     def closeEvent(self, event):

--- a/tofpa_panel_base.ui
+++ b/tofpa_panel_base.ui
@@ -209,6 +209,13 @@
          </property>
         </widget>
        </item>
+       <item>
+        <widget class="QCheckBox" name="exportToAixmCheckBox">
+         <property name="text">
+          <string>Export to AIXM 5.1.1</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
     </item>

--- a/tofpa_panel_base.ui
+++ b/tofpa_panel_base.ui
@@ -51,10 +51,27 @@
        <item row="1" column="1">
         <widget class="QgsMapLayerComboBox" name="thresholdLayerCombo"/>
        </item>
-       <item row="2" column="0" colspan="2">
+       <item row="2" column="0">
+        <widget class="QLabel" name="obstaclesLabel">
+         <property name="text">
+          <string>Obstacles Layer:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QgsMapLayerComboBox" name="obstaclesLayerCombo"/>
+       </item>
+       <item row="3" column="0" colspan="2">
         <widget class="QCheckBox" name="useSelectedFeatureCheckBox">
          <property name="text">
           <string>Use selected features only</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0" colspan="2">
+        <widget class="QCheckBox" name="includeObstaclesCheckBox">
+         <property name="text">
+          <string>Include survey obstacles analysis</string>
          </property>
         </widget>
        </item>
@@ -191,6 +208,75 @@
            <string>End to Start (-1)</string>
           </property>
          </item>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item>
+     <widget class="QGroupBox" name="obstaclesGroup">
+      <property name="title">
+       <string>Survey Obstacles Parameters</string>
+      </property>
+      <layout class="QFormLayout" name="formLayout_3">
+       <item row="0" column="0">
+        <widget class="QLabel" name="obstacleBufferLabel">
+         <property name="text">
+          <string>Safety Buffer (m):</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QDoubleSpinBox" name="obstacleBufferSpin">
+         <property name="minimum">
+          <double>0.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>1000.000000000000000</double>
+         </property>
+         <property name="decimals">
+          <number>2</number>
+         </property>
+         <property name="value">
+          <double>10.00</double>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="obstacleHeightFieldLabel">
+         <property name="text">
+          <string>Height Field:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QComboBox" name="obstacleHeightFieldCombo">
+         <property name="editable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="minObstacleHeightLabel">
+         <property name="text">
+          <string>Min Height (m):</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QDoubleSpinBox" name="minObstacleHeightSpin">
+         <property name="minimum">
+          <double>0.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>1000.000000000000000</double>
+         </property>
+         <property name="decimals">
+          <number>2</number>
+         </property>
+         <property name="value">
+          <double>5.00</double>
+         </property>
         </widget>
        </item>
       </layout>


### PR DESCRIPTION
# AIXM Export Feature

## Overview
The TOFPA plugin now supports exporting TOFPA surfaces and reference lines to AIXM 5.1.1 format for aviation data exchange compatibility.

## AIXM 5.1.1 Compliance
- Follows AIXM 5.1.1 schema specifications
- Uses proper GML 3.2 geometry encoding
- Includes required namespace declarations
- WGS84 coordinate system (EPSG:4326)
- Proper temporal encoding with time slices

## Generated Elements

### TOFPA Surface
- Exported as `aixm:NavigationArea`
- Type: `TAKEOFF_CLIMB_SURFACE`
- Designator: `TOFPA_AOC_TypeA`
- 3D polygon geometry in GML format

### Reference Line
- Exported as `aixm:Curve`
- Designator: `TOFPA_REFERENCE_LINE`
- 3D line geometry in GML format

## Usage
1. Create TOFPA surface as normal
2. Check "Export to AIXM 5.1.1" checkbox
3. Run calculation
4. Select output file location
5. AIXM XML file will be generated

## File Format
- Extension: `.xml`
- Encoding: UTF-8
- Schema: AIXM 5.1.1 with GML 3.2
- Coordinate order: Latitude, Longitude, Altitude

## Validation
The generated AIXM files are compliant with AIXM 5.1.1 schema and can be validated against official AIXM XSD files.
