### PR TITLE
fix: Qt.ScrollBarPolicy compat for Qt6 (QGIS 4.0)

### DIFF
--- a/tofpa_dockwidget.py
+++ b/tofpa_dockwidget.py
@@ -70,12 +70,15 @@ class TofpaDockWidget(QDockWidget, FORM_CLASS):
         scroll = QScrollArea()
         scroll.setObjectName("tofpaScrollArea")
         scroll.setWidgetResizable(True)
-        try:
-            from qgis.PyQt.QtCore import Qt
-            scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.AlwaysOff)
-        except AttributeError:
-            from qgis.PyQt.QtCore import Qt
-            scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)  # type: ignore[attr-defined]
+        from qgis.PyQt.QtCore import Qt
+        # Qt6 (QGIS 4): Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+        # Qt5 (QGIS 3): Qt.ScrollBarAlwaysOff
+        _policy = (
+            getattr(Qt.ScrollBarPolicy, "ScrollBarAlwaysOff", None)  # Qt6
+            or getattr(Qt, "ScrollBarAlwaysOff", None)               # Qt5
+        )
+        if _policy is not None:
+            scroll.setHorizontalScrollBarPolicy(_policy)
         scroll.setWidget(self.dockWidgetContents)
         self.setWidget(scroll)
 


### PR DESCRIPTION
Qt5: Qt.ScrollBarAlwaysOff
Qt6: Qt.ScrollBarPolicy.ScrollBarAlwaysOff (not .AlwaysOff)

The try/except was testing both wrong Qt6 variants and crashing on QGIS 4.0. Replaced with getattr-based detection that works on both Qt versions without exceptions.
<img width="1229" height="1048" alt="{F8AC415C-293F-48EC-8F47-667E71AD098E}" src="https://github.com/user-attachments/assets/f5e3ce6e-7e61-4b8b-908a-5b9241ad3336" />
