### PR TITLE
feat(#27): Add contour lines for TOFPA surface

### DIFF
--- a/core/_contour_utils.py
+++ b/core/_contour_utils.py
@@ -1,0 +1,193 @@
+# -*- coding: utf-8 -*-
+"""
+_contour_utils.py — Pure-Python contour helpers for TOFPA stepped surfaces.
+
+No QGIS dependency: safe to import in unit tests without a QGIS context.
+
+Ported from FLYGHT7/qOLS scripts/_contour_utils.py (issue #84) and adapted
+for the TOFPA plugin geometry (issue #27).
+
+The TOFPA AOC Type A surface has a single constant slope and two width zones:
+
+  * Expanding zone   [0, distance_to_max_width]:  half-width grows linearly.
+  * Constant-width   [distance_to_max_width, surface_length]: max half-width.
+
+All distances and elevations in metres.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import ceil, floor
+from typing import List
+
+
+# ---------------------------------------------------------------------------
+# Data containers
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class ContourSpec:
+    """Geometry-agnostic specification for a single contour line.
+
+    Attributes:
+        elevation:            The surface elevation this contour represents (m).
+        distance_from_origin: Distance along the surface centre axis from pt_01D.
+        half_width:           Half the width of the contour line at this distance.
+    """
+    elevation: float
+    distance_from_origin: float
+    half_width: float
+
+
+# ---------------------------------------------------------------------------
+# Elevation level helpers
+# ---------------------------------------------------------------------------
+
+def contour_elevations(z_start: float, z_end: float, interval: int) -> List[float]:
+    """Return whole-number elevation levels spaced *interval* metres apart.
+
+    Only levels strictly inside the open interval (z_start, z_end] are
+    returned.  The surface start elevation is not a contour — the surface
+    polygon already starts there.
+
+    Args:
+        z_start:  Elevation at the near (DER) end of the surface, metres.
+        z_end:    Elevation at the far end of the surface, metres.
+        interval: Contour spacing in metres.  Must be a positive integer.
+                  Pass 0 to disable (returns empty list).
+
+    Returns:
+        Sorted list of float elevations.  Empty when interval <= 0 or
+        z_end <= z_start (flat / descending surfaces).
+
+    Examples:
+        >>> contour_elevations(21.7, 81.7, 10)
+        [30.0, 40.0, 50.0, 60.0, 70.0, 80.0]
+        >>> contour_elevations(0.0, 10.0, 10)
+        [10.0]
+        >>> contour_elevations(10.0, 10.0, 10)
+        []
+        >>> contour_elevations(21.7, 81.7, 0)
+        []
+    """
+    if interval <= 0 or z_end <= z_start:
+        return []
+    # Add a small epsilon so z_start is strictly excluded when it falls exactly
+    # on an interval boundary (contract: open at z_start, closed at z_end).
+    first = int(ceil(z_start / interval + 1e-9)) * interval
+    last = int(floor(z_end / interval)) * interval
+    return [float(v) for v in range(first, last + 1, interval)]
+
+
+# ---------------------------------------------------------------------------
+# Per-section geometry helpers
+# ---------------------------------------------------------------------------
+
+def contour_specs_for_linear_section(
+    z_section_start: float,
+    z_section_end: float,
+    slope: float,
+    d_offset: float,
+    near_half_width: float,
+    divergence_ratio: float,
+    elevations: List[float],
+) -> List[ContourSpec]:
+    """Compute ContourSpecs for a **linearly sloped** trapezoidal section.
+
+    The section runs from *d_offset* (elevation *z_section_start*) to
+    ``d_offset + (z_section_end - z_section_start) / slope`` (elevation
+    *z_section_end*).
+
+    Half-width at distance *d* from the global origin::
+
+        half_width(d) = near_half_width + d * divergence_ratio
+
+    where *near_half_width* is the half-width at *d_offset*.
+
+    Args:
+        z_section_start:  Elevation at the start of this section.
+        z_section_end:    Elevation at the end of this section.
+        slope:            Vertical rise per horizontal metre (> 0).
+        d_offset:         Horizontal distance of the section start from origin.
+        near_half_width:  Half-width at *d_offset*.
+        divergence_ratio: Lateral growth per metre (e.g. 0.125 for 12.5 %).
+        elevations:       Pre-computed list of target elevations.
+
+    Returns:
+        List of :class:`ContourSpec` in elevation order.
+    """
+    if slope <= 0:
+        return []
+
+    specs: List[ContourSpec] = []
+    for z_c in elevations:
+        if not (z_section_start - 1e-9 < z_c <= z_section_end + 1e-9):
+            continue
+        d_in_section = (z_c - z_section_start) / slope
+        d_from_origin = d_offset + d_in_section
+        half_w = near_half_width + d_from_origin * divergence_ratio
+        specs.append(ContourSpec(
+            elevation=z_c,
+            distance_from_origin=d_from_origin,
+            half_width=half_w,
+        ))
+    return specs
+
+
+def contour_specs_for_takeoff(
+    z_start: float,
+    slope_ratio: float,
+    distance_to_max_width: float,
+    surface_length: float,
+    near_half_width: float,
+    max_half_width: float,
+    divergence_ratio: float,
+    elevations: List[float],
+) -> List[ContourSpec]:
+    """Compute ContourSpecs for the TOFPA AOC Type A Climb Surface.
+
+    The surface has a single constant slope throughout but two width zones:
+
+    * **Expanding zone** ``[0, distance_to_max_width]``:
+      ``half_width = near_half_width + d * divergence_ratio``
+    * **Constant-width zone** ``[distance_to_max_width, surface_length]``:
+      ``half_width = max_half_width``
+
+    Elevation increases linearly: ``z(d) = z_start + d * slope_ratio``.
+
+    Args:
+        z_start:               Elevation at pt_01D (DER), metres.
+        slope_ratio:           Vertical rise per horizontal metre (e.g. 0.012).
+        distance_to_max_width: Distance at which the surface reaches max width.
+        surface_length:        Total length of the climb surface from pt_01D.
+        near_half_width:       Half of widthDep at pt_01D.
+        max_half_width:        Half of maxWidthDep.
+        divergence_ratio:      Lateral growth per metre (e.g. 0.125).
+        elevations:            Pre-computed list of target elevations.
+
+    Returns:
+        List of :class:`ContourSpec` in elevation order.
+    """
+    if slope_ratio <= 0:
+        return []
+
+    z_end = z_start + surface_length * slope_ratio
+    specs: List[ContourSpec] = []
+
+    for z_c in elevations:
+        if not (z_start - 1e-9 < z_c <= z_end + 1e-9):
+            continue
+        d = (z_c - z_start) / slope_ratio
+        if d > surface_length + 1e-6:
+            continue
+        # Width zone
+        if d <= distance_to_max_width:
+            half_w = near_half_width + d * divergence_ratio
+        else:
+            half_w = max_half_width
+        specs.append(ContourSpec(
+            elevation=z_c,
+            distance_from_origin=d,
+            half_width=half_w,
+        ))
+    return specs

--- a/core/models.py
+++ b/core/models.py
@@ -48,6 +48,9 @@ class TofpaParams:
     export_kmz: bool
     export_aixm: bool
 
+    # Contour generation (issue #27) — 0 = disabled
+    contour_interval_m: int = 0
+
     @classmethod
     def from_dict(cls, d: dict) -> "TofpaParams":
         """Build from the dict returned by ``TofpaDockWidget.get_parameters()``."""
@@ -63,6 +66,7 @@ class TofpaParams:
             use_selected_feature=bool(d.get("use_selected_feature", True)),
             export_kmz=bool(d.get("export_kmz", False)),
             export_aixm=bool(d.get("export_aixm", False)),
+            contour_interval_m=int(d.get("contour_interval_m", 0)),
         )
 
 

--- a/tofpa.py
+++ b/tofpa.py
@@ -17,11 +17,12 @@
 from qgis.PyQt.QtCore import QCoreApplication
 from qgis.PyQt.QtGui import QColor, QIcon
 from qgis.PyQt.QtWidgets import QFileDialog, QAction
-from .utils.compat import FIELD_INT, FIELD_STRING, DOCK_RIGHT  # MIGA-01, MIGA-05
+from .utils.compat import FIELD_INT, FIELD_STRING, FIELD_DOUBLE, DOCK_RIGHT  # MIGA-01, MIGA-05
 from qgis.core import (QgsProject, QgsVectorLayer, QgsFeature, QgsGeometry,
                       QgsPoint, QgsPointXY, QgsField, QgsPolygon, QgsLineString, Qgis,
                       QgsFillSymbol, QgsLineSymbol, QgsMarkerSymbol, QgsVectorFileWriter, QgsCoordinateTransform,
-                      QgsCoordinateReferenceSystem, QgsWkbTypes)
+                      QgsCoordinateReferenceSystem, QgsWkbTypes,
+                      QgsPalLayerSettings, QgsVectorLayerSimpleLabeling)
 
 import logging
 import os.path
@@ -45,10 +46,12 @@ logger = logging.getLogger('TOFPA')
 try:
     from .core.models import ObstacleParams, TofpaParams
     from .core.obstacles import ObstacleAnalyzer
+    from .core._contour_utils import contour_elevations, contour_specs_for_takeoff
     from .utils.export import generate_aixm_file
 except ImportError:
     from core.models import ObstacleParams, TofpaParams
     from core.obstacles import ObstacleAnalyzer
+    from core._contour_utils import contour_elevations, contour_specs_for_takeoff
     from utils.export import generate_aixm_file
 
 # ---------------------------------------------------------------------------
@@ -428,6 +431,62 @@ class TOFPA:
         v_layer.renderer().setSymbol(symbol)
         v_layer.triggerRepaint()
         
+        # Contour layer generation (issue #27)
+        if params.contour_interval_m > 0:
+            _dist_to_max_w = (max_width_tofpa / 2 - width_tofpa / 2) / TOFPA_DIVERGENCE_RATIO
+            _z_surface_end = ze + TOFPA_SURFACE_LENGTH * TOFPA_CLIMB_GRADIENT
+            _elevs = contour_elevations(ze, _z_surface_end, params.contour_interval_m)
+            _all_specs = contour_specs_for_takeoff(
+                z_start=ze,
+                slope_ratio=TOFPA_CLIMB_GRADIENT,
+                distance_to_max_width=_dist_to_max_w,
+                surface_length=TOFPA_SURFACE_LENGTH,
+                near_half_width=width_tofpa / 2,
+                max_half_width=max_width_tofpa / 2,
+                divergence_ratio=TOFPA_DIVERGENCE_RATIO,
+                elevations=_elevs,
+            )
+            if _all_specs:
+                _clayer = QgsVectorLayer(
+                    f"LineStringZ?crs={map_srid}",
+                    "RWY_TOFPA_Contours",
+                    "memory",
+                )
+                _clayer.dataProvider().addAttributes([
+                    QgsField('ID', FIELD_INT),
+                    QgsField('surface_elevation', FIELD_DOUBLE),
+                ])
+                _clayer.updateFields()
+
+                _cfeats = []
+                for _i, _spec in enumerate(_all_specs):
+                    _ctr = pt_01D.project(_spec.distance_from_origin, azimuth)
+                    _l2d = _ctr.project(_spec.half_width, azimuth + 90)
+                    _r2d = _ctr.project(_spec.half_width, azimuth - 90)
+                    _lpt = QgsPoint(_l2d.x(), _l2d.y(), _spec.elevation)
+                    _rpt = QgsPoint(_r2d.x(), _r2d.y(), _spec.elevation)
+                    _feat = QgsFeature()
+                    _feat.setGeometry(QgsGeometry(QgsLineString([_lpt, _rpt])))
+                    _feat.setAttributes([_i + 1, _spec.elevation])
+                    _cfeats.append(_feat)
+                _clayer.dataProvider().addFeatures(_cfeats)
+
+                _sym = QgsLineSymbol.createSimple({'color': 'red', 'width': '0.5'})
+                _clayer.renderer().setSymbol(_sym)
+
+                _pal = QgsPalLayerSettings()
+                _pal.fieldName = 'surface_elevation'
+                _pal.enabled = True
+                _clayer.setLabeling(QgsVectorLayerSimpleLabeling(_pal))
+                _clayer.setLabelsEnabled(True)
+
+                QgsProject.instance().addMapLayers([_clayer])
+                _clayer.triggerRepaint()
+                logger.debug(
+                    "Contour layer added — %d lines at %dm interval",
+                    len(_cfeats), params.contour_interval_m,
+                )
+
         # Process survey obstacles if requested
         obstacles_layers = []
         if include_obstacles and obstacles_layer_id:

--- a/tofpa_dockwidget.py
+++ b/tofpa_dockwidget.py
@@ -331,7 +331,9 @@ class TofpaDockWidget(QDockWidget, FORM_CLASS):
             'min_obstacle_height': self.minObstacleHeightSpin.value(),
             # New shadow analysis parameters
             'enable_shadow_analysis': self.enableShadowAnalysisCheckBox.isChecked() and self.includeObstaclesCheckBox.isChecked(),
-            'shadow_tolerance': self.shadowToleranceSpin.value()
+            'shadow_tolerance': self.shadowToleranceSpin.value(),
+            # Contour generation (issue #27)
+            'contour_interval_m': int(round(self.contourIntervalSpin.value())),
         }
 
     def closeEvent(self, event):

--- a/tofpa_panel_base.ui
+++ b/tofpa_panel_base.ui
@@ -397,6 +397,47 @@
      </widget>
     </item>
     <item>
+     <widget class="QGroupBox" name="contoursGroup">
+      <property name="title">
+       <string>Contours</string>
+      </property>
+      <layout class="QFormLayout" name="formLayout_contours">
+       <item row="0" column="0">
+        <widget class="QLabel" name="contourIntervalLabel">
+         <property name="text">
+          <string>Contour Interval (m):</string>
+         </property>
+         <property name="toolTip">
+          <string>Generate elevation contour lines every X metres. Set to 0 to disable. Lines are labelled with the surface elevation value.</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QSpinBox" name="contourIntervalSpin">
+         <property name="toolTip">
+          <string>Generate elevation contour lines every X metres. Set to 0 to disable.</string>
+         </property>
+         <property name="minimum">
+          <number>0</number>
+         </property>
+         <property name="maximum">
+          <number>500</number>
+         </property>
+         <property name="singleStep">
+          <number>10</number>
+         </property>
+         <property name="value">
+          <number>0</number>
+         </property>
+         <property name="suffix">
+          <string> m</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item>
      <widget class="QGroupBox" name="exportGroup">
       <property name="title">
        <string>Export Options</string>
@@ -495,6 +536,7 @@
   <tabstop>minObstacleHeightSpin</tabstop>
   <tabstop>enableShadowAnalysisCheckBox</tabstop>
   <tabstop>shadowToleranceSpin</tabstop>
+  <tabstop>contourIntervalSpin</tabstop>
   <tabstop>exportToKmzCheckBox</tabstop>
   <tabstop>exportToAixmCheckBox</tabstop>
   <tabstop>calculateButton</tabstop>


### PR DESCRIPTION
# feat(#27): Add contour lines for TOFPA surface

## Summary

Analysts need to see elevation bands on the TOFPA AOC Type A surface — e.g. "here the surface is 10 m, here 20 m, here 30 m" — for quick obstacle assessment without reading raw numbers. Previously only the outer polygon was available.

This PR adds a **Contour Interval** field to the TOFPA panel. When set (e.g. `10`), the plugin generates a second QGIS layer of red labelled lines on top of the surface. Set to `0` (default) to disable — the plugin behaves exactly as before.

Port of the algorithm implemented in [FLYGHT7/qOLS#84](https://github.com/FLYGHT7/qOLS/issues/84), adapted for the TOFPA AOC Type A geometry.
<img width="1420" height="683" alt="{A886E39F-0E3B-4F44-B2CE-82A58D979472}" src="https://github.com/user-attachments/assets/883a6696-9498-4afb-85d6-b73682953174" />


## New layer produced

| Surface          | Layer name           |
| ---------------- | -------------------- |
| TOFPA AOC Type A | `RWY_TOFPA_Contours` |

The layer is `LineStringZ`, styled with a **red 0.5-pt line**, and carries a `surface_elevation` field displayed as a map label. One line per interval step, spanning the full width of the surface at each elevation.

---

## What changed

### New: `core/_contour_utils.py`

Pure-Python geometry module — **no QGIS dependency**, fully unit-testable.

| Symbol                                                     | Description                                               |
| ---------------------------------------------------------- | --------------------------------------------------------- |
| `ContourSpec(elevation, distance_from_origin, half_width)` | Frozen dataclass for one contour line                     |
| `contour_elevations(z_start, z_end, interval)`             | Returns integer-multiple elevations in `(z_start, z_end]` |
| `contour_specs_for_linear_section(...)`                    | Specs for a linearly sloped trapezoidal section           |
| `contour_specs_for_takeoff(...)`                           | Specs for the TOFPA diverging + constant-width geometry   |

The TOFPA surface has a single constant slope (`1.2 %`) and two width zones:

- **Expanding zone** `[0, distance_to_max_width]`: half-width grows at `12.5 % / m`
- **Constant-width zone** `[distance_to_max_width, 10 000 m]`: half-width fixed at `max_width / 2`

### `core/models.py`

`TofpaParams` gains one new field:

```python
contour_interval_m: int = 0   # 0 = disabled
```

Parsed from `get_parameters()` via `from_dict()`.

### `tofpa_panel_base.ui`

New **Contours** `QGroupBox` inserted before _Export Options_:

- `contourIntervalSpin` — `QSpinBox`, range 0–500 m, step 10, suffix ` m`
- Default `0` = disabled

### `tofpa_dockwidget.py`

`get_parameters()` now emits:

```python
'contour_interval_m': int(round(self.contourIntervalSpin.value()))
```

### `tofpa.py`

After the surface polygon is added to the map, a contour block runs when `params.contour_interval_m > 0`:

```python
_elevs = contour_elevations(ze, z_surface_end, params.contour_interval_m)
_all_specs = contour_specs_for_takeoff(
    z_start=ze,
    slope_ratio=TOFPA_CLIMB_GRADIENT,           # 0.012
    distance_to_max_width=_dist_to_max_w,
    surface_length=TOFPA_SURFACE_LENGTH,         # 10 000 m
    near_half_width=width_tofpa / 2,
    max_half_width=max_width_tofpa / 2,
    divergence_ratio=TOFPA_DIVERGENCE_RATIO,     # 0.125
    elevations=_elevs,
)
# → creates RWY_TOFPA_Contours LineStringZ layer
```

Each `ContourSpec` is projected from `pt_01D` along the takeoff azimuth to find the centre, then fanned out left/right by `half_width`.

Also adds `QgsPalLayerSettings`, `QgsVectorLayerSimpleLabeling` to `qgis.core` imports and `FIELD_DOUBLE` to the `compat` import.

---

## Files changed

| File                     | Change                                                     |
| ------------------------ | ---------------------------------------------------------- |
| `core/_contour_utils.py` | **New** — 180 lines, no QGIS dependency                    |
| `core/models.py`         | +2 lines (`contour_interval_m` field + `from_dict` update) |
| `tofpa_panel_base.ui`    | +44 lines (Contours QGroupBox + tabstop)                   |
| `tofpa_dockwidget.py`    | +2 lines (`contour_interval_m` in `get_parameters`)        |
| `tofpa.py`               | +56 lines (imports + contour generation block)             |

---

## Tests

| Test file                        | Module under test                          | Tests |
| -------------------------------- | ------------------------------------------ | ----- |
| `tests/test_issue27_contours.py` | `core/_contour_utils.py`, `core/models.py` | 15    |

| ID    | Description                                                                     |
| ----- | ------------------------------------------------------------------------------- |
| CT-01 | `contour_elevations()` — typical range                                          |
| CT-02 | `contour_elevations()` — open at start exactly on boundary                      |
| CT-03 | `contour_elevations()` — disabled (interval=0)                                  |
| CT-04 | `contour_elevations()` — flat surface                                           |
| CT-05 | `contour_elevations()` — single level exactly at z_end                          |
| CT-06 | `contour_specs_for_takeoff()` — elevations in expanding zone                    |
| CT-07 | `contour_specs_for_takeoff()` — elevation in constant-width zone                |
| CT-08 | `contour_specs_for_takeoff()` — empty when interval=0                           |
| CT-09 | `contour_specs_for_takeoff()` — zero slope returns empty                        |
| CT-10 | `contour_specs_for_takeoff()` — distance_from_origin and half_width correctness |
| CT-11 | `TofpaParams.from_dict()` — `contour_interval_m` defaults to 0                  |
| CT-12 | `TofpaParams.from_dict()` — `contour_interval_m` correctly parsed               |
| CT-13 | TOFPA defaults (ze=0, surface_end=120, interval=10) → 12 levels                 |
| CT-14 | All `ContourSpec.elevation` values within surface range                         |
| CT-15 | `ContourSpec.half_width` never exceeds `max_half_width`                         |

**104 / 104 tests passing** (89 pre-existing + 15 new).

---

## Acceptance criteria

- [ ] `contour_interval_m = 0` (or empty) → no contour layer created, no error
- [ ] `contour_interval_m = 10` → lines at 10, 20, 30 … m (integer multiples only)
- [ ] `surface_elevation` attribute value matches the map label
- [ ] Lines styled red, 0.5 pt width
- [ ] Layer is `LineStringZ` (elevations preserved)
- [ ] Works for both runway directions (`s = 0` and `s = -1`)
- [ ] Plugin still loads on QGIS 3.x (Qt5) and QGIS 4.x (Qt6)
- [ ] 104 / 104 tests passing

---

## How to test manually

1. Open QGIS with a runway centerline + threshold point layer.
2. Load the TOFPA plugin from this branch.
3. Fill in the surface parameters as usual.
4. Set **Contour Interval** to `10`.
5. Click **Calculate**.
6. Verify that `RWY_TOFPA_Contours` layer appears with red lines labelled `10.0`, `20.0`, … at the correct positions over the surface polygon.
7. Repeat with **Contour Interval = 0** and confirm no contour layer is created.
